### PR TITLE
Added a dontSeeLinkInSelector

### DIFF
--- a/src/CodeceptionUtilities.php
+++ b/src/CodeceptionUtilities.php
@@ -42,6 +42,38 @@ class CodeceptionUtilities extends Module
     }
 
     /**
+     * Checks that a link does not appear in a particular CSS or XPath selector.
+     *
+     * @param string $text
+     *   Text to ensure doesn't exist.
+     * @param string $link
+     *   URL the text should not link to.
+     * @param string $cssOrXpath
+     *   The selector in which to look for the lack of link.
+     */
+    public function dontSeeLinkInSelector($text, $link, $cssOrXpath)
+    {
+        $moduleName = SuiteManager::$actions['seeInTitle'];
+        /** @var WebInterface $module */
+        $module = $this->getModule($moduleName);
+
+        if ($link) {
+            if (Locator::isCSS($cssOrXpath)) {
+                $link_selector = sprintf("%s a[href*='%s']", $cssOrXpath, $link);
+            } else {
+                $link_selector = sprintf("%s//a[contains(@href,'%s')]", $cssOrXpath, $link);
+            }
+        } else {
+            if (Locator::isCSS($cssOrXpath)) {
+                $link_selector = sprintf("%s a", $cssOrXpath);
+            } else {
+                $link_selector = sprintf("%s//a", $cssOrXpath);
+            }
+        }
+        $module->dontSee($text, $link_selector);
+    }
+
+    /**
      * See element has been applied a style.
      *
      * Allows you to check a single element has a css style assigned.


### PR DESCRIPTION
Quick change to add an opposite to seeLinkInSelector, which checks that a link doesn't appear in a selector. Might need some work, it's basically a copy paste.
