### PR TITLE
UPD composer.json on ixis/codeception-utilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 
     "require": {
         "php": ">=5.4.0",
-        "codeception/codeception": "~2.0.0"
+        "codeception/codeception": "^2.4"
     },
 
     "autoload": {


### PR DESCRIPTION
When i add to composer.json 
`
{
  "repositories": [
    {
      "type":"vcs",
      "url":"git@github.com:ixis/codeception-utilities.git"
    }
  ],
  "require": {
    "ixis/codeception-utilities": "dev-develop"
  }
}`
And do `composer install` i have next result 
 - Updating codeception/codeception (2.4.1 => 2.0.16): Loading from cache
 - Installing ixis/codeception-utilities (dev-develop d0975ab): Cloning d0975abcd

@eethann, @ixisandyr pls update composer.json in line 20 `"codeception/codeception": "^2.4"` on `ixis/codeception-utilities`
Thanks!)